### PR TITLE
fix typo in code example of the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Prettifies several typographic marks, some cases are outlined below.
 ## `beautifyText(text)`
 
 ```js
-beautifyText('a --- "b (tm) c"'));
+beautifyText('a --- "b (tm) c"');
 // -> 'a \u2014 “b ™ c”'
 ```
 


### PR DESCRIPTION
There is a small typo in the code sample part of the Readme file. :beers: 
